### PR TITLE
Switch to api v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or install it yourself as:
 
 ## Usage
 
-Please refer to the [Typeform Data API Documentation](http://helpcenter.typeform.com/hc/en-us/articles/200071986-Data-API) for more information about the API, or follow the examples below:
+Please refer to the [Typeform Data API Documentation](https://www.typeform.com/help/data-api/) for more information about the API, or follow the examples below:
 
 ```ruby
 require 'typeform'

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,8 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
 
+Rake::TestTask.new do |t|
+  t.pattern = "test/**/*_test.rb"
+end
+
+task default: :test

--- a/lib/typeform.rb
+++ b/lib/typeform.rb
@@ -37,9 +37,9 @@ module Typeform
   class Typeform
     include HTTParty
 
-    @@base_uri = "https://api.typeform.com/v0/"
+    @@base_uri = "https://api.typeform.com/v1/"
     @@api_key = ""
-    headers({ 
+    headers({
       'User-Agent' => "typeform-rest-#{VERSION}",
       'Content-Type' => 'application/json; charset=utf-8',
       'Accept-Encoding' => 'gzip, deflate'

--- a/test/fixtures/one_form.yml
+++ b/test/fixtures/one_form.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.typeform.com/v0/form/MQNqoh?key=<TYPEFORM_API_KEY>
+    uri: https://api.typeform.com/v1/form/some-questionnaire?key=some-key
     body:
       encoding: US-ASCII
       string: ''
@@ -56,44 +56,44 @@ http_interactions:
       string: '{"http_status":200,"stats":{"responses":{"showing":11,"total":11,"completed":4,"locked":0}},"questions":[{"id":"list_2294179_choice","question":"What
         do you want to buy for Christmas?"},{"id":"list_2294224_choice","question":"What
         will you buy for Thanksgiving?"},{"id":"terms_2294239","question":"This is
-        an intro"}],"responses":[{"id":"1","completed":"0","token":"04b17f8d859fdc825f294d2304a202af","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-10-25
+        an intro"}],"responses":[{"completed":"0","token":"04b17f8d859fdc825f294d2304a202af","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-10-25
         08:38:37","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.104
-        Safari\/537.36","referer":"http:\/\/dev.eventhub.com:3000\/","network_id":"2bdccd629bf1292cfe94be47c25cd694cb029d6c"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"id":"2","completed":"0","token":"fac659b611352af25cdc6568cebaa69f","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
+        Safari\/537.36","referer":"http:\/\/dev.eventhub.com:3000\/","network_id":"2bdccd629bf1292cfe94be47c25cd694cb029d6c"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"completed":"0","token":"fac659b611352af25cdc6568cebaa69f","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
         06:30:47","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111
-        Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/fields\/","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"id":"3","completed":"0","token":"8c335acd13039962d727968939dcf0a6","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
+        Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/fields\/","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"completed":"0","token":"8c335acd13039962d727968939dcf0a6","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
         06:33:12","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111
-        Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/fields\/","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"id":"4","completed":"1","token":"ad92fe78d9e995251f4331c36e81eb09","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
+        Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/fields\/","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"completed":"1","token":"ad92fe78d9e995251f4331c36e81eb09","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
         06:33:13","date_submit":"2014-11-10 06:33:21","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111
         Safari\/537.36","referer":"","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"iPhone
-        6","list_2294224_choice":""}},{"id":"5","completed":"1","token":"2666e1b15c3b83dd0444994e35cc7108","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
+        6","list_2294224_choice":""}},{"completed":"1","token":"2666e1b15c3b83dd0444994e35cc7108","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
         06:42:49","date_submit":"2014-11-10 06:43:01","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111
         Safari\/537.36","referer":"","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"iPad
-        2","list_2294224_choice":"Just testing"}},{"id":"6","completed":"1","token":"d425dda4989b47c4351ab130560145c2","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
+        2","list_2294224_choice":"Just testing"}},{"completed":"1","token":"d425dda4989b47c4351ab130560145c2","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-10
         06:47:11","date_submit":"2014-11-10 06:47:24","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.111
         Safari\/537.36","referer":"","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"iPhone
-        6","list_2294224_choice":"Nothing","terms_2294239":"1"}},{"id":"7","completed":"1","token":"ab130a085631f2f263e24d76c4364bb3","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
+        6","list_2294224_choice":"Nothing","terms_2294239":"1"}},{"completed":"1","token":"ab130a085631f2f263e24d76c4364bb3","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
         02:46:54","date_submit":"2014-11-15 02:48:55","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.122
         Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/distribute\/","network_id":"9bf85c77089b52c7e63e58e2611498e9cb4fb0f1"},"hidden":[],"answers":{"list_2294179_choice":"iPhone
-        6","list_2294224_choice":"Just testing","terms_2294239":"1"}},{"id":"8","completed":"0","token":"5efddaedc433d147fc1d860474bfc2f0","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
+        6","list_2294224_choice":"Just testing","terms_2294239":"1"}},{"completed":"0","token":"5efddaedc433d147fc1d860474bfc2f0","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
         20:17:27","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.122
-        Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/analyze\/","network_id":"2bdccd629bf1292cfe94be47c25cd694cb029d6c"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"id":"9","completed":"0","token":"e0f8171a805e37052abff687c0842e72","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
+        Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/analyze\/","network_id":"2bdccd629bf1292cfe94be47c25cd694cb029d6c"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"completed":"0","token":"e0f8171a805e37052abff687c0842e72","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
         20:38:39","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_7_2) AppleWebKit\/535.7 (KHTML, like Gecko) Chrome\/16.0.912.63
-        Safari\/535.7","referer":"","network_id":"c6066258f9a79c2655d9470686aee61bdb209fd2"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"id":"10","completed":"0","token":"bb71fa2f549c2684b01208e9bde3f0ed","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
+        Safari\/535.7","referer":"","network_id":"c6066258f9a79c2655d9470686aee61bdb209fd2"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"completed":"0","token":"bb71fa2f549c2684b01208e9bde3f0ed","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-15
         20:38:58","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_7_2) AppleWebKit\/535.7 (KHTML, like Gecko) Chrome\/16.0.912.63
-        Safari\/535.7","referer":"","network_id":"211e40cf800cd1ea4ec8c1ff1851b6bc642874dc"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"id":"11","completed":"0","token":"be5a2f51bc7ba7973f33909e919e3402","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-20
+        Safari\/535.7","referer":"","network_id":"211e40cf800cd1ea4ec8c1ff1851b6bc642874dc"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}},{"completed":"0","token":"be5a2f51bc7ba7973f33909e919e3402","locked":"0","metadata":{"browser":"default","platform":"other","date_land":"2014-11-20
         14:22:51","date_submit":"0000-00-00 00:00:00","user_agent":"Mozilla\/5.0 (Macintosh;
         Intel Mac OS X 10_10_0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/38.0.2125.122
         Safari\/537.36","referer":"https:\/\/admin.typeform.com\/form\/196165\/fields\/","network_id":"b29f3f4201efed89b04f0c225fa9fc580d67c2d9"},"hidden":[],"answers":{"list_2294179_choice":"","list_2294224_choice":""}}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Nov 2014 11:30:27 GMT
 recorded_with: VCR 2.9.3

--- a/test/form/form_test.rb
+++ b/test/form/form_test.rb
@@ -2,7 +2,7 @@ require './test/test_helper'
 
 class TypeformFormTest < Minitest::Test
   def setup
-    Typeform.api_key = ENV["TYPEFORM_API_KEY"]
+    Typeform.api_key = 'some-key'
   end
 
   def test_exists
@@ -11,7 +11,7 @@ class TypeformFormTest < Minitest::Test
 
   def test_it_gives_back_a_single_form
     VCR.use_cassette('one_form') do
-      form = Typeform::Form.new(ENV["TYPEFORM_ID"])
+      form = Typeform::Form.new('some-questionnaire')
       assert_equal Typeform::Form, form.class
 
       entries = form.all_entries


### PR DESCRIPTION
This includes a few fixes (including #1)
- Uses Typeform API v1
- Allows running tests via `rake test`
- Links to the current version of Typeform API docs
